### PR TITLE
Added script for automated OEP table release on databus and MOSS

### DIFF
--- a/databusclient_example.py
+++ b/databusclient_example.py
@@ -55,9 +55,9 @@ def create_dataset_from_yaml(yaml_path: str):
         group_abstract=data["group"].get("abstract", None),
         group_description=data["group"].get("description", None))
 
-
     return dataset
 
-dataset = create_dataset_from_yaml("./example/new_dataset.yml")
 
-deploy(dataset, API_KEY)
+if __name__ == "__main__":
+    dataset = create_dataset_from_yaml("./example/new_dataset.yml")
+    deploy(dataset, API_KEY)

--- a/oep_metadata/oep_group.yaml
+++ b/oep_metadata/oep_group.yaml
@@ -1,4 +1,0 @@
-group: OEP
-title: OEP Group
-abstract: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
-description: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.


### PR DESCRIPTION
For each table in given schema list of OEP  a dataset is released in the OEP Group on the databus.
Additionally, related metadata (if metadata is valid) is connected to dataset via MOSS.