### PR TITLE
OEP metadata update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 beautifulsoup4>=4.11.1
 pyyaml>=6.0
 databusclient==0.3
+oem2orm


### PR DESCRIPTION
Closes #23 

- [x] register data and metadata variant per artefact version registration
- [x] update metadata on oep

Will update the metadata on the OEP with the artefact databus URI.

Tested on https://openenergy-platform.org/dataedit/view/model_draft?query=&tags=364

